### PR TITLE
Replacing busio.I2C writeto() and readfrom_into() with combined writeto_then_readfrom

### DIFF
--- a/library/circuitpython_adapter/__init__.py
+++ b/library/circuitpython_adapter/__init__.py
@@ -37,9 +37,8 @@ class not_SMBus:
         while not self.i2c.try_lock():
             pass
         try:
-            self.i2c.writeto(i2c_address, bytes([register]), stop=False)
             buffer = bytearray(bit_width)
-            self.i2c.readfrom_into(i2c_address, buffer)
+            self.i2c.writeto_then_readfrom(i2c_address, bytes([register]), buffer)
             return list(buffer)
 
         finally:


### PR DESCRIPTION
This is a simple replacement of two i2c methods with the combined `writeto_then_readfrom()`. This is required for CircuitPython 6.x due to changes in API, see #1.

This is compatible with the two current production releases 5.3.x and 6.x but not the older ones.

I have `mpy-cross` compiled this and tested in on a Feather nRF52840 Express running `6.0.0` and Enviro+ FeatherWing and it works fine.
